### PR TITLE
9 feat 직업 페이지 UI 구성하기

### DIFF
--- a/app/archer/page.tsx
+++ b/app/archer/page.tsx
@@ -29,7 +29,7 @@ const ArcherPage = () => {
       <section className="mb-12">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">1차 전직</h2>
         <div className="bg-white rounded-lg shadow-md p-6">
-          <h3 className="text-xl font-bold mb-3">아처 (Archer)</h3>
+          <h3 className="text-xl font-bold mb-3">궁수 (Archer)</h3>
           <p className="text-gray-600 mb-4">레벨 10에 전직 가능</p>
           <Link
             href="/archer/archer/1st"
@@ -55,12 +55,12 @@ const ArcherPage = () => {
               <div className="space-y-3">
                 {/* 2차 전직 */}
                 <div>
-                  <h4 className="font-semibold text-gray-700 mb-2">
+                  <h4 className="font-semibold text-blue-700 dark:text-blue-300 mb-2">
                     2차 전직 (Lv.30)
                   </h4>
                   <Link
                     href={`/archer/${job.id}/2nd`}
-                    className="text-blue-600 hover:underline block"
+                    className="text-blue-600 dark:text-blue-400 hover:underline block"
                   >
                     → {job.name} 육성 가이드
                   </Link>
@@ -69,22 +69,22 @@ const ArcherPage = () => {
                 {/* 3차, 4차 전직 */}
                 {job.thirdJobs.map((third) => (
                   <div key={third.id}>
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-purple-700 dark:text-purple-300 mb-2">
                       3차 전직 (Lv.70)
                     </h4>
                     <Link
                       href={`/archer/${job.id}/${third.id}/3rd`}
-                      className="text-blue-600 hover:underline block mb-3"
+                      className="text-purple-600 dark:text-purple-400 hover:underline block mb-3"
                     >
                       → {third.name} 육성 가이드
                     </Link>
 
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-amber-700 dark:text-amber-300 mb-2">
                       4차 전직 (Lv.120)
                     </h4>
                     <Link
                       href={`/archer/${job.id}/${third.id}/4th`}
-                      className="text-blue-600 hover:underline block"
+                      className="text-amber-600 dark:text-amber-400 hover:underline block"
                     >
                       → {third.fourthJob} 육성 가이드
                     </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,22 +1,17 @@
 @import "tailwindcss";
 
-@theme {
-  --color-background: #f9fafb;
-  --color-foreground: #171717;
-  --color-background-dark: #101828;
-  --color-foreground-dark: #f9fafb;
-}
-
 @variant dark (&:where(.dark, .dark *));
 
 :root {
-  --background: var(--color-background);
-  --foreground: var(--color-foreground);
+  color-scheme: light;
+  --background: #f9fafb;
+  --foreground: #171717;
 }
 
 .dark {
-  --background: var(--color-background-dark);
-  --foreground: var(--color-foreground-dark);
+  color-scheme: dark;
+  --background: #111827;
+  --foreground: #f9fafb;
 }
 
 body {
@@ -24,4 +19,39 @@ body {
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
   transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* 재사용 가능한 커스텀 클래스 */
+@layer components {
+  .page-title {
+    @apply text-4xl font-bold text-gray-900 dark:text-gray-100;
+  }
+
+  .section-title {
+    @apply text-2xl font-bold text-gray-800 dark:text-gray-100;
+  }
+
+  .job-title {
+    @apply text-2xl font-bold text-gray-900 dark:text-gray-100;
+  }
+
+  .subsection-title {
+    @apply text-xl font-bold text-gray-900 dark:text-gray-100;
+  }
+
+  .tier-label {
+    @apply font-semibold text-gray-700 dark:text-gray-200;
+  }
+
+  .description-text {
+    @apply text-gray-600 dark:text-gray-300;
+  }
+
+  .card-bg {
+    @apply bg-white dark:bg-gray-800 rounded-lg shadow-md;
+  }
+
+  .card-hover {
+    @apply bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-xl transition-shadow;
+  }
 }

--- a/app/magician/page.tsx
+++ b/app/magician/page.tsx
@@ -47,7 +47,7 @@ const MagicianPage = () => {
       <section className="mb-12">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">1차 전직</h2>
         <div className="bg-white rounded-lg shadow-md p-6">
-          <h3 className="text-xl font-bold mb-3">매지션 (Magician)</h3>
+          <h3 className="text-xl font-bold mb-3">마법사 (Magician)</h3>
           <p className="text-gray-600 mb-4">레벨 8에 전직 가능</p>
           <Link
             href="/magician/magician/1st"
@@ -73,12 +73,12 @@ const MagicianPage = () => {
               <div className="space-y-3">
                 {/* 2차 전직 */}
                 <div>
-                  <h4 className="font-semibold text-gray-700 mb-2">
+                  <h4 className="font-semibold text-blue-700 dark:text-blue-300 mb-2">
                     2차 전직 (Lv.30)
                   </h4>
                   <Link
                     href={`/magician/${job.id}/2nd`}
-                    className="text-blue-600 hover:underline block"
+                    className="text-blue-600 dark:text-blue-400 hover:underline block"
                   >
                     → {job.name} 육성 가이드
                   </Link>
@@ -87,22 +87,22 @@ const MagicianPage = () => {
                 {/* 3차, 4차 전직 */}
                 {job.thirdJobs.map((third) => (
                   <div key={third.id}>
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-purple-700 dark:text-purple-300 mb-2">
                       3차 전직 (Lv.70)
                     </h4>
                     <Link
                       href={`/magician/${job.id}/${third.id}/3rd`}
-                      className="text-blue-600 hover:underline block mb-3"
+                      className="text-purple-600 dark:text-purple-400 hover:underline block mb-3"
                     >
                       → {third.name} 육성 가이드
                     </Link>
 
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-amber-700 dark:text-amber-300 mb-2">
                       4차 전직 (Lv.120)
                     </h4>
                     <Link
                       href={`/magician/${job.id}/${third.id}/4th`}
-                      className="text-blue-600 hover:underline block"
+                      className="text-amber-600 dark:text-amber-400 hover:underline block"
                     >
                       → {third.fourthJob} 육성 가이드
                     </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,19 +25,17 @@ const Home = () => {
       {/* 직업 카테고리 */}
       <section className="flex-1 py-20 bg-gray-50 dark:bg-gray-900">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-12">
-            직업 선택
-          </h2>
+          <h2 className="page-title text-3xl text-center mb-12">직업 선택</h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             {jobCategories.map((category) => (
               <Link
                 key={category.id}
                 href={`/${category.id}`}
-                className="bg-white dark:bg-gray-800 rounded-lg shadow-md dark:shadow-gray-900/50 p-6 hover:shadow-xl dark:hover:shadow-gray-900 transition-shadow cursor-pointer group"
+                className="card-hover p-6 cursor-pointer group dark:shadow-gray-900/50 dark:hover:shadow-gray-900"
               >
                 <div className="text-center">
-                  <h3 className="text-2xl font-bold mb-4 text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                  <h3 className="job-title mb-4 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                     {category.name}
                   </h3>
 

--- a/app/thief/page.tsx
+++ b/app/thief/page.tsx
@@ -31,7 +31,7 @@ const ThiefPage = () => {
       <section className="mb-12">
         <h2 className="text-2xl font-bold mb-6 text-gray-800">1차 전직</h2>
         <div className="bg-white rounded-lg shadow-md p-6">
-          <h3 className="text-xl font-bold mb-3">로그 (Rogue)</h3>
+          <h3 className="text-xl font-bold mb-3">도적 (Rogue)</h3>
           <p className="text-gray-600 mb-4">레벨 10에 전직 가능</p>
           <Link
             href="/thief/rogue/1st"
@@ -57,12 +57,12 @@ const ThiefPage = () => {
               <div className="space-y-3">
                 {/* 2차 전직 */}
                 <div>
-                  <h4 className="font-semibold text-gray-700 mb-2">
+                  <h4 className="font-semibold text-blue-700 dark:text-blue-300 mb-2">
                     2차 전직 (Lv.30)
                   </h4>
                   <Link
                     href={`/thief/${job.id}/2nd`}
-                    className="text-blue-600 hover:underline block"
+                    className="text-blue-600 dark:text-blue-400 hover:underline block"
                   >
                     → {job.name} 육성 가이드
                   </Link>
@@ -71,22 +71,22 @@ const ThiefPage = () => {
                 {/* 3차, 4차 전직 */}
                 {job.thirdJobs.map((third) => (
                   <div key={third.id}>
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-purple-700 dark:text-purple-300 mb-2">
                       3차 전직 (Lv.70)
                     </h4>
                     <Link
                       href={`/thief/${job.id}/${third.id}/3rd`}
-                      className="text-blue-600 hover:underline block mb-3"
+                      className="text-purple-600 dark:text-purple-400 hover:underline block mb-3"
                     >
                       → {third.name} 육성 가이드
                     </Link>
 
-                    <h4 className="font-semibold text-gray-700 mb-2">
+                    <h4 className="font-semibold text-amber-700 dark:text-amber-300 mb-2">
                       4차 전직 (Lv.120)
                     </h4>
                     <Link
                       href={`/thief/${job.id}/${third.id}/4th`}
-                      className="text-blue-600 hover:underline block"
+                      className="text-amber-600 dark:text-amber-400 hover:underline block"
                     >
                       → {third.fourthJob} 육성 가이드
                     </Link>

--- a/app/warrior/page.tsx
+++ b/app/warrior/page.tsx
@@ -37,10 +37,10 @@ const WarriorPage = () => {
       <section className="mb-12">
         <h2 className="section-title mb-6">1차 전직</h2>
         <div className="card-bg p-6">
-          <h3 className="subsection-title mb-3">소드맨 (Swordman)</h3>
+          <h3 className="subsection-title mb-3">전사 (Warrior)</h3>
           <p className="description-text mb-4">레벨 10에 전직 가능</p>
           <Link
-            href="/warrior/swordman/1st"
+            href="/warrior/warrior/1st"
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
           >
             1차 육성 가이드 보기

--- a/app/warrior/page.tsx
+++ b/app/warrior/page.tsx
@@ -27,18 +27,18 @@ const WarriorPage = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <div className="mb-8">
-        <h1 className="text-4xl font-bold mb-4">전사</h1>
-        <p className="text-gray-600 text-lg">
+        <h1 className="page-title mb-4">전사</h1>
+        <p className="description-text text-lg">
           높은 체력과 방어력을 가진 근접 전투의 달인
         </p>
       </div>
 
       {/* 1차 전직 */}
       <section className="mb-12">
-        <h2 className="text-2xl font-bold mb-6 text-gray-800">1차 전직</h2>
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h3 className="text-xl font-bold mb-3">소드맨 (Swordman)</h3>
-          <p className="text-gray-600 mb-4">레벨 10에 전직 가능</p>
+        <h2 className="section-title mb-6">1차 전직</h2>
+        <div className="card-bg p-6">
+          <h3 className="subsection-title mb-3">소드맨 (Swordman)</h3>
+          <p className="description-text mb-4">레벨 10에 전직 가능</p>
           <Link
             href="/warrior/swordman/1st"
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
@@ -50,22 +50,17 @@ const WarriorPage = () => {
 
       {/* 2차 전직 이후 */}
       <section>
-        <h2 className="text-2xl font-bold mb-6 text-gray-800">2차 전직 이후</h2>
+        <h2 className="section-title mb-6">2차 전직 이후</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {secondJobs.map((job) => (
-            <div
-              key={job.id}
-              className="bg-white rounded-lg shadow-md p-6 hover:shadow-xl transition-shadow"
-            >
-              <h3 className="text-2xl font-bold mb-3">{job.name}</h3>
-              <p className="text-gray-600 mb-4">{job.description}</p>
+            <div key={job.id} className="card-hover p-6">
+              <h3 className="job-title mb-3">{job.name}</h3>
+              <p className="description-text mb-4">{job.description}</p>
 
               <div className="space-y-3">
                 {/* 2차 전직 */}
                 <div>
-                  <h4 className="font-semibold text-gray-700 mb-2">
-                    2차 전직 (Lv.30)
-                  </h4>
+                  <h4 className="tier-label mb-2">2차 전직 (Lv.30)</h4>
                   <Link
                     href={`/warrior/${job.id}/2nd`}
                     className="text-blue-600 hover:underline block"
@@ -77,9 +72,7 @@ const WarriorPage = () => {
                 {/* 3차, 4차 전직 */}
                 {job.thirdJobs.map((third) => (
                   <div key={third.id}>
-                    <h4 className="font-semibold text-gray-700 mb-2">
-                      3차 전직 (Lv.70)
-                    </h4>
+                    <h4 className="tier-label mb-2">3차 전직 (Lv.70)</h4>
                     <Link
                       href={`/warrior/${job.id}/${third.id}/3rd`}
                       className="text-blue-600 hover:underline block mb-3"
@@ -87,9 +80,7 @@ const WarriorPage = () => {
                       → {third.name} 육성 가이드
                     </Link>
 
-                    <h4 className="font-semibold text-gray-700 mb-2">
-                      4차 전직 (Lv.120)
-                    </h4>
+                    <h4 className="tier-label mb-2">4차 전직 (Lv.120)</h4>
                     <Link
                       href={`/warrior/${job.id}/${third.id}/4th`}
                       className="text-blue-600 hover:underline block"

--- a/app/warrior/page.tsx
+++ b/app/warrior/page.tsx
@@ -60,10 +60,12 @@ const WarriorPage = () => {
               <div className="space-y-3">
                 {/* 2차 전직 */}
                 <div>
-                  <h4 className="tier-label mb-2">2차 전직 (Lv.30)</h4>
+                  <h4 className="tier-label mb-2 text-blue-700 dark:text-blue-300">
+                    2차 전직 (Lv.30)
+                  </h4>
                   <Link
                     href={`/warrior/${job.id}/2nd`}
-                    className="text-blue-600 hover:underline block"
+                    className="text-blue-600 dark:text-blue-400 hover:underline block"
                   >
                     → {job.name} 육성 가이드
                   </Link>
@@ -72,18 +74,22 @@ const WarriorPage = () => {
                 {/* 3차, 4차 전직 */}
                 {job.thirdJobs.map((third) => (
                   <div key={third.id}>
-                    <h4 className="tier-label mb-2">3차 전직 (Lv.70)</h4>
+                    <h4 className="tier-label mb-2 text-purple-700 dark:text-purple-300">
+                      3차 전직 (Lv.70)
+                    </h4>
                     <Link
                       href={`/warrior/${job.id}/${third.id}/3rd`}
-                      className="text-blue-600 hover:underline block mb-3"
+                      className="text-purple-600 dark:text-purple-400 hover:underline block mb-3"
                     >
                       → {third.name} 육성 가이드
                     </Link>
 
-                    <h4 className="tier-label mb-2">4차 전직 (Lv.120)</h4>
+                    <h4 className="tier-label mb-2 text-amber-700 dark:text-amber-300">
+                      4차 전직 (Lv.120)
+                    </h4>
                     <Link
                       href={`/warrior/${job.id}/${third.id}/4th`}
-                      className="text-blue-600 hover:underline block"
+                      className="text-amber-600 dark:text-amber-400 hover:underline block"
                     >
                       → {third.fourthJob} 육성 가이드
                     </Link>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -54,7 +54,7 @@ const Footer = () => {
           <div>
             <h3 className="text-lg font-bold mb-4">업데이트</h3>
             <p className="text-gray-400 dark:text-gray-500 text-sm">
-              최종 업데이트: 2025년 12월 9일
+              최종 업데이트: 2025년 12월 16일
             </p>
           </div>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#9 

## 📝작업 내용

- 정확한 직업명 및 전직시 명칭에 각각의 색상 추가함

### 스크린샷 (선택)
<img width="3840" height="1904" alt="image" src="https://github.com/user-attachments/assets/544f6252-7e2f-4e8d-96d3-66c7232e977b" />

## 💬리뷰 요구사항(선택)
